### PR TITLE
Multiple code improvements - squid:S1197, squid:S1854, squid:S1481, squid:S1155, squid:S2131

### DIFF
--- a/library/src/main/java/com/onlylemi/mapview/library/MapView.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/MapView.java
@@ -312,7 +312,7 @@ public class MapView extends SurfaceView implements SurfaceHolder.Callback {
      */
     public float[] convertMapXYToScreenXY(float x, float y) {
         Matrix invertMatrix = new Matrix();
-        float value[] = {x, y};
+        float[] value = {x, y};
         currentMatrix.invert(invertMatrix);
         invertMatrix.mapPoints(value);
         return value;

--- a/library/src/main/java/com/onlylemi/mapview/library/layer/BitmapLayer.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/layer/BitmapLayer.java
@@ -59,7 +59,7 @@ public class BitmapLayer extends MapBaseLayer {
             currentRotateDegrees) {
         if (isVisible && bitmap != null) {
             canvas.save();
-            float goal[] = {location.x, location.y};
+            float[] goal = {location.x, location.y};
             if (!autoScale) {
                 currentMatrix.mapPoints(goal);
             } else {

--- a/library/src/main/java/com/onlylemi/mapview/library/layer/LocationLayer.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/layer/LocationLayer.java
@@ -117,7 +117,7 @@ public class LocationLayer extends MapBaseLayer {
             currentRotateDegrees) {
         if (isVisible && currentPosition != null) {
             canvas.save();
-            float goal[] = {currentPosition.x, currentPosition.y};
+            float[] goal = {currentPosition.x, currentPosition.y};
             currentMatrix.mapPoints(goal);
 
             canvas.drawCircle(goal[0], goal[1], defaultLocationCircleRadius,

--- a/library/src/main/java/com/onlylemi/mapview/library/layer/MapLayer.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/layer/MapLayer.java
@@ -52,7 +52,7 @@ public class MapLayer extends MapBaseLayer {
     private void initMapLayer() {
         float zoom = getInitZoom(mapView.getWidth(), mapView.getHeight(), image.getWidth(), image
                 .getHeight());
-        Log.i(TAG, zoom + "");
+        Log.i(TAG, Float.toString(zoom));
         mapView.setCurrentZoom(zoom, 0, 0);
 
         float width = mapView.getWidth() - zoom * image.getWidth();

--- a/library/src/main/java/com/onlylemi/mapview/library/layer/MarkLayer.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/layer/MarkLayer.java
@@ -60,7 +60,7 @@ public class MarkLayer extends MapBaseLayer {
     @Override
     public void onTouch(MotionEvent event) {
         if (marks != null) {
-            if (marks.size() != 0) {
+            if (!marks.isEmpty()) {
                 float[] goal = mapView.convertMapXYToScreenXY(event.getX(), event.getY());
                 for (int i = 0; i < marks.size(); i++) {
                     if (MapMath.getDistanceBetweenTwoPoints(goal[0], goal[1],
@@ -89,10 +89,10 @@ public class MarkLayer extends MapBaseLayer {
             currentRotateDegrees) {
         if (isVisible && marks != null) {
             canvas.save();
-            if (marks.size() != 0) {
+            if (!marks.isEmpty()) {
                 for (int i = 0; i < marks.size(); i++) {
                     PointF mark = marks.get(i);
-                    float goal[] = {mark.x, mark.y};
+                    float[] goal = {mark.x, mark.y};
                     currentMatrix.mapPoints(goal);
 
                     paint.setColor(Color.BLACK);

--- a/library/src/main/java/com/onlylemi/mapview/library/layer/RouteLayer.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/layer/RouteLayer.java
@@ -67,17 +67,15 @@ public class RouteLayer extends MapBaseLayer {
             currentRotateDegrees) {
         if (isVisible && routeList != null && nodeList != null) {
             canvas.save();
-            if (routeList.size() != 0 && nodeList.size() != 0) {
+            if (!routeList.isEmpty() && !nodeList.isEmpty()) {
                 // draw route
                 for (int i = 0; i < routeList.size() - 1; i++) {
-                    // start node
-                    PointF start = nodeList.get(routeList.get(i));
-                    // end node
-                    PointF end = nodeList.get(routeList.get(i + 1));
+                    nodeList.get(routeList.get(i));
+                    nodeList.get(routeList.get(i + 1));
 
-                    float goal1[] = {nodeList.get(routeList.get(i)).x,
+                    float[] goal1 = {nodeList.get(routeList.get(i)).x,
                             nodeList.get(routeList.get(i)).y};
-                    float goal2[] = {nodeList.get(routeList.get(i + 1)).x,
+                    float[] goal2 = {nodeList.get(routeList.get(i + 1)).x,
                             nodeList.get(routeList.get(i + 1)).y};
                     currentMatrix.mapPoints(goal1);
                     currentMatrix.mapPoints(goal2);
@@ -86,9 +84,9 @@ public class RouteLayer extends MapBaseLayer {
                 }
 
                 // draw bmp
-                float goal1[] = {nodeList.get(routeList.get(0)).x,
+                float[] goal1 = {nodeList.get(routeList.get(0)).x,
                         nodeList.get(routeList.get(0)).y};
-                float goal2[] = {
+                float[]  goal2 = {
                         nodeList.get(routeList.get(routeList.size() - 1)).x,
                         nodeList.get(routeList.get(routeList.size() - 1)).y};
                 currentMatrix.mapPoints(goal1);

--- a/library/src/main/java/com/onlylemi/mapview/library/utils/math/TSPNearestNeighbour.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/utils/math/TSPNearestNeighbour.java
@@ -26,7 +26,7 @@ public class TSPNearestNeighbour {
         list = new ArrayList<>();
     }
 
-    public List<Integer> tsp(float matrix[][]) {
+    public List<Integer> tsp(float[][] matrix) {
         numberOfNodes = matrix[0].length;
         int[] visited = new int[numberOfNodes];
         visited[0] = 1;
@@ -36,11 +36,10 @@ public class TSPNearestNeighbour {
 
         // System.out.print(0 + "\t");
         list.add(0);
-        float min = INF;
         while (!stack.isEmpty()) {
             element = stack.peek();
             i = 0;
-            min = INF;
+            float min = INF;
             while (i < numberOfNodes) {
                 if (matrix[element][i] < INF && visited[i] == 0) {
                     if (min > matrix[element][i]) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1854 - Dead stores should be removed.
squid:S1481 - Unused local variables should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
George Kankava