### PR TITLE
Fix array index out of bound when nodes changed

### DIFF
--- a/library/src/main/java/com/onlylemi/mapview/library/layer/RouteLayer.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/layer/RouteLayer.java
@@ -67,9 +67,17 @@ public class RouteLayer extends MapBaseLayer {
             currentRotateDegrees) {
         if (isVisible && routeList != null && nodeList != null) {
             canvas.save();
+
+            drawing:
             if (!routeList.isEmpty() && !nodeList.isEmpty()) {
                 // draw route
                 for (int i = 0; i < routeList.size() - 1; i++) {
+
+                    if (routeList.get(i) >= nodeList.size() ||
+                            routeList.get(i + 1) >= nodeList.size()) {
+                        break drawing;
+                    }
+
                     float[] goal1 = {nodeList.get(routeList.get(i)).x,
                             nodeList.get(routeList.get(i)).y};
                     float[] goal2 = {nodeList.get(routeList.get(i + 1)).x,
@@ -95,6 +103,7 @@ public class RouteLayer extends MapBaseLayer {
                         goal2[0] - routeEndBmp.getWidth() / 2, goal2[1]
                                 - routeEndBmp.getHeight(), paint);
             }
+
             canvas.restore();
         }
     }


### PR DESCRIPTION
## Array index out of bound 出现的情景：

为了实现 `RouteLayer` 的路线随着 `LocationLayer` 的移动而渐渐消失，
需要对 `routeList` 和 `nodeList` 进行更改。

由于点击事件在分发的高层级就会触发 `refresh()`，

所以在点击过快时，很有可能 `nodeList` 没有得到更新，

此时直接重绘就会导致 `draw()` 方法中出现 index out of bound 。
## 解决思路：

给绘制过程赋予一个 `label`，在 `for` 中检查是否会出现数组越界。

一旦出现数组越界，直接 `break label`，跳出绘制过程，调用 `canvas.restore()`。
